### PR TITLE
fix: unreleased materials in plan prevent farm route design

### DIFF
--- a/src/views/Material/index.js
+++ b/src/views/Material/index.js
@@ -964,7 +964,10 @@ export default defineComponent({
     ...mapActions(usePenguinDataStore, ['loadPenguinData', 'fetchPenguinData']),
     ...mapActions(useMaterialValueStore, ['loadMaterialValueData', 'calcStageEfficiency']),
     isPlannerUnavailableItem(id) {
-      return this.materialTable[id]?.type === MaterialTypeEnum.MOD_TOKEN;
+      return (
+        this.materialTable[id]?.type === MaterialTypeEnum.MOD_TOKEN ||
+        !this.$root.isImplementedMaterial(id)
+      );
     },
     num10k(num) {
       return num >= 10000


### PR DESCRIPTION
Prevents farming route design from considering unreleased materials, since there's no way to obtain them, and that causes the plan to be marked infeasible by the linprog solver.

Occurs when you switch to CN server, add an operator who requires episode 13 materials (e.g. Vendela S2M3), and then switch back to US server.