### PR TITLE
fix: adjust margin-top for first child in Material styles

### DIFF
--- a/src/views/Material/index.scss
+++ b/src/views/Material/index.scss
@@ -346,7 +346,7 @@ $highlight-colors-dark: #eee, #e6ee9c, #90caf9, #b39ddb, #fff59d;
       margin-right: 8px;
     }
     &:first-child h5 {
-      margin-top: 0;
+      margin-top: 8px;
     }
     .num-item {
       margin: 0 8px 8px 0;


### PR DESCRIPTION
解决 Today 标签展示不全的问题。

| Before                                                       | After                                                        |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| <img width="719" alt="截屏2025-01-06 11 08 04" src="https://github.com/user-attachments/assets/624bc085-daf5-4458-9c31-ebfa7a3592fe" /> | <img width="720" alt="截屏2025-01-06 11 11 50" src="https://github.com/user-attachments/assets/e61caf25-5603-4477-b54d-611894bad2a5" /> |

