### PR TITLE
fix: update EN wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 - [OCR Space](https://ocr.space/)（OCR）
 - Wiki
   - CN - [PRTS Wiki](http://prts.wiki/)
-  - US - [GamePress](https://gamepress.gg/arknights/)
+  - US - [Arknights Terra Wiki](https://arknights.wiki.gg/)
   - JP - [Wikiru](https://arknights.wikiru.jp/)
   - KR - [Namu Wiki](https://namu.wiki/w/%EB%AA%85%EC%9D%BC%EB%B0%A9%EC%A3%BC)
 

--- a/src/locales/us/common.json
+++ b/src/locales/us/common.json
@@ -1,5 +1,5 @@
 {
-  "wikiToJump": "GamePress Wiki",
+  "wikiToJump": "Arknights Terra Wiki",
   "viewOnWiki": "Go to @:(common.wikiToJump)",
   "operator": "Operator",
   "promotion": "Elite",

--- a/src/main.js
+++ b/src/main.js
@@ -249,26 +249,34 @@ new Vue({
     getLocalCharacterName(name, locale) {
       return this.$i18n.messages[locale || this.locale].character[name];
     },
-    async getWikiHref({ name, appellation }) {
-      if (!(name && appellation)) return '';
+    async getWikiHref({ name }) {
+      if (!name) return '';
+      const localeName = this.getLocalCharacterName(name, this.locale === 'tw' ? 'cn' : null);
+      if (!localeName) return '';
       switch (this.locale) {
         case 'cn':
         case 'tw':
-          return `https://prts.wiki/w/${this.getLocalCharacterName(name, 'cn')}`;
-        case 'jp': {
-          const jpName = this.getLocalCharacterName(name);
+          return `https://prts.wiki/w/${localeName}`;
+        case 'jp':
           return `https://arknights.wikiru.jp/index.php?${await encodeURIComponentEUCJP(
-            jpName === 'W' ? `${jpName}(プレイアブル)` : jpName,
+            localeName === 'W' ? `${localeName}(プレイアブル)` : localeName,
           )}`;
-        }
         case 'kr':
-          return `https://namu.wiki/w/${this.getLocalCharacterName(name)}(명일방주)`;
+          return `https://namu.wiki/w/${localeName}(명일방주)`;
         default:
-          return `https://arknights.wiki.gg/wiki/${appellation}`;
+          return `https://arknights.wiki.gg/wiki/${localeName}`;
       }
     },
+    getCNWikiHref({ name }) {
+      if (!name) return '';
+      const localeName = this.getLocalCharacterName(name, 'cn');
+      if (!localeName) return '';
+      return `https://prts.wiki/w/${localeName}`;
+    },
     async openWikiHref(char) {
-      window.open(await this.getWikiHref(char), '_blank');
+      // Jump to CN wiki if not released
+      const href = (await this.getWikiHref(char)) || this.getCNWikiHref(char);
+      if (href) window.open(href, '_blank');
     },
     pureName(name) {
       return name.toLowerCase?.().replace(/ /g, '');

--- a/src/main.js
+++ b/src/main.js
@@ -264,7 +264,7 @@ new Vue({
         case 'kr':
           return `https://namu.wiki/w/${this.getLocalCharacterName(name)}(명일방주)`;
         default:
-          return `https://gamepress.gg/arknights/operator/${appellation.toLowerCase()}`;
+          return `https://arknights.wiki.gg/wiki/${appellation}`;
       }
     },
     async openWikiHref(char) {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -121,7 +121,10 @@
           Wiki
           <ul class="mdui-m-t-0">
             <li>CN - <a href="http://prts.wiki/" target="_blank">PRTS Wiki</a></li>
-            <li>EN - <a href="https://gamepress.gg/arknights/" target="_blank">GamePress</a></li>
+            <li
+              >EN -
+              <a href="https://arknights.wiki.gg/" target="_blank">Arknights Terra Wiki</a></li
+            >
             <li>JP - <a href="https://arknights.wikiru.jp/" target="_blank">Wikiru</a></li>
             <li
               >KR -


### PR DESCRIPTION
The GamePress Arknights site had been on life support since a big crash last June, with no updates at all since then.  As of this week, it appears to be down entirely.

Arknights Terra Wiki is actively maintained and has detailed operator information.  It seems like the natural choice to replace GamePress as the target of links.